### PR TITLE
chore(workflows): Introduce PR

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,26 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+      name: Lint
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Git Checkout
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 2
+
+        - name: Set up Node.js
+          uses: actions/setup-node@v3
+          with:
+            node-version-file: '.nvmrc'
+            cache: yarn
+        - name: Install Dependencies
+          run: yarn install --frozen-lockfile
+        - name: Run Lint
+          run: yarn lint

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen


### PR DESCRIPTION
This is important, because this repo is open-source so if a people contribute to the project is pr will "test" before merging.
And it saves time for the maintainer who doesn't have to test this on their machine at every PR.