### PR TITLE
Fixed icon to toggle dark mode from light mode

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -24,7 +24,7 @@ const ModeToggle = () => {
       className="group"
       onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
     >
-      <Sun className="h-6 w-6 fill-gray-100 stroke-gray-500 transition group-hover:fill-gray-200 group-hover:stroke-gray-700 dark:hidden [@media(prefers-color-scheme:dark)]:fill-white [@media(prefers-color-scheme:dark)]:stroke-white [@media(prefers-color-scheme:dark)]:group-hover:fill-white [@media(prefers-color-scheme:dark)]:group-hover:stroke-teal-600" />
+      <Sun className="h-6 w-6 fill-gray-100 stroke-gray-500 transition group-hover:fill-gray-200 group-hover:stroke-gray-700 dark:hidden [@media(prefers-color-scheme:dark)]:fill-white [@media(prefers-color-scheme:dark)]:stroke-gray-900 [@media(prefers-color-scheme:dark)]:group-hover:fill-white [@media(prefers-color-scheme:dark)]:group-hover:stroke-teal-600" />
       <Moon className="hidden h-6 w-6 fill-gray-700 stroke-gray-500 transition dark:block [@media(prefers-color-scheme:dark)]:group-hover:stroke-gray-400 [@media_not_(prefers-color-scheme:dark)]:fill-teal-400/10 [@media_not_(prefers-color-scheme:dark)]:stroke-white" />
     </button>
   );


### PR DESCRIPTION
The Sun icon is not visible in light mode when the user has dark mode on their device but light mode on site.

Changes made at `navigation.tsx`
Line - 27
col - 221

When the user has dark mode on their device and switches to light mode on site then they cannot see the sun icon as it is stroked with a white colour

Footage of before
https://github.com/openjs-foundation/open-visualization/assets/108511809/417bef89-aaa3-4d4a-869a-bc134a39132d

After updated
https://github.com/openjs-foundation/open-visualization/assets/108511809/ca5d363f-7cfe-446a-8878-d56d90dc423f
