### PR TITLE
Updated Twitter references to X logo and related changes

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,4 @@
-import TwitterIcon from './icons/twitter';
+import XIcon from './icons/x';
 import GoogleCalendarIcon from './icons/googleCalendar';
 import LinkedInIcon from './icons/linkedin';
 import type { FC } from 'react';
@@ -14,9 +14,9 @@ type FooterProps = {
 
 const social = [
   {
-    name: 'Twitter',
-    href: 'https://twitter.com/openjsf',
-    icon: TwitterIcon,
+    name: 'X',
+    href: 'https://x.com/openjsf',
+    icon: XIcon,
   },
   {
     name: 'LinkedIn',

--- a/components/icons/x.tsx
+++ b/components/icons/x.tsx
@@ -1,0 +1,9 @@
+import type { FC } from 'react';
+
+const XIcon: FC = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+export default XIcon;

--- a/customtypes/home/mocks.json
+++ b/customtypes/home/mocks.json
@@ -134,7 +134,7 @@
       "__TYPE__": "LinkContent",
       "value": {
         "__TYPE__": "ExternalLink",
-        "url": "http://twitter.com"
+        "url": "https://x.com"
       }
     },
     "about_image": {
@@ -254,7 +254,7 @@
       "__TYPE__": "LinkContent",
       "value": {
         "__TYPE__": "ExternalLink",
-        "url": "http://twitter.com"
+        "url": "https://x.com"
       }
     },
     "community_outlinks": {

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -19,7 +19,7 @@ const authors: Metadata['authors'] = [
   },
 ];
 const publisher = 'OpenJS Foundation';
-const twitterHandle = '@openjsf';
+const xHandle = '@openjsf';
 
 export const createMetadata: MetadataGenerator = (
   title,
@@ -68,9 +68,9 @@ export const createMetadata: MetadataGenerator = (
       url: new URL(path ?? '/', process.env.NEXT_PUBLIC_SITE_URL).toString(),
     },
     publisher,
-    twitter: {
-      card: 'summary_large_image',
-      creator: twitterHandle,
+    x: {
+      handle: xHandle,
+      creator: xHandle,
     },
     viewport: {
       minimumScale: 1,


### PR DESCRIPTION
Hi @brianleroux @haydenbleasel,
@voxpelli @mcollina @ljharb @justmoon 
I’ve worked on resolving [issue #18](https://github.com/openjs-foundation/open-visualization/issues/18). Here’s what I’ve updated:
	•	Replaced the **Twitter** icon with the new **X** logo.
	•	Updated all references from **Twitter** to **X** in the footer.
	•	Updated social media links to direct to **x.com.**

I hope these changes align with the current branding updates. Please review the pull request, and if everything looks good, I’d be grateful if you could merge it. Let me know if there’s anything else needed!

Thank you!

<img width="327" alt="Screenshot 2024-12-07 at 12 56 56 PM" src="https://github.com/user-attachments/assets/d2ec0519-be66-4994-9788-771fcf5fb4c2">
<img width="394" alt="Screenshot 2024-12-07 at 12 59 05 PM" src="https://github.com/user-attachments/assets/b65026e6-7d00-41d9-8026-8f5f955c25ca">
