### PR TITLE
Changing project preview grid to 3 columns on the home page

### DIFF
--- a/components/projects-preview.tsx
+++ b/components/projects-preview.tsx
@@ -21,27 +21,27 @@ const ProjectCard = ({
     href={`/projects#${project_title?.toLowerCase().replace(/\s+/g, '-')}`}
     className="group flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden transition-transform duration-300 hover:scale-102 hover:shadow-lg"
   >
-    <div className="relative aspect-[16/10] w-full">
+    <div className="relative aspect-[16/12] w-full">
       <Image
         src={project_image.url ?? ''}
         alt={project_title ?? ''}
         fill
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-        className="object-cover p-4 bg-white dark:bg-gray-800"
+        sizes="(max-width: 768px) 100vw, 33vw"
+        className="object-cover p-3 bg-white dark:bg-gray-800"
         priority={false}
       />
     </div>
 
-    <div className="p-6 flex flex-col flex-grow">
-      <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">
+    <div className="p-4 flex flex-col flex-grow">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
         {project_title}
       </h3>
-      <p className="text-base text-gray-600 dark:text-gray-300 mb-4 flex-grow">
+      <p className="text-sm text-gray-600 dark:text-gray-300 mb-3 flex-grow line-clamp-3">
         {project_description}
       </p>
-      <span className="inline-flex items-center text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300">
+      <span className="inline-flex items-center text-sm text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300">
         Learn more about {project_title}
-        <ArrowUpRight className="ml-2 h-4 w-4" />
+        <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
       </span>
     </div>
   </Link>
@@ -58,7 +58,7 @@ const ProjectsPreview: FC<ProjectsProps> = ({ title, description, items }) => (
           {description}
         </p>
       </div> */}
-      <div className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-[repeat(auto-fit,minmax(0,400px))] justify-center">
+      <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-3">
         {items.map((project, index) => (
           <ProjectCard key={index} {...project} />
         ))}

--- a/content/projects.json
+++ b/content/projects.json
@@ -35,13 +35,13 @@
               "description": "High-performance WebGL-based graph visualization engine for massive datasets."
             },
             {
-              "name": "Perspective",
+              "name": "perspective",
               "url": "https://perspective-dev.github.io/",
               "image": "/visgl/images/frameworks/perspective.png",
               "description": "Interactive analytics and data visualization component for large and streaming datasets."
             },
             {
-              "name": "GeoDa.AI",
+              "name": "geoda.ai",
               "url": "https://geodaai.github.io/",
               "image": "/visgl/images/frameworks/geoda.png",
               "description": "Spatial data analysis for GenAI with powerful libraries and AI assistant tools."


### PR DESCRIPTION
[PREVIEW](https://open-visualization-git-3-column-homepage-project-preview-openjs.vercel.app/)

Changing project preview grid to 3 columns on the home page, since there are more projects now.

Also, lowercase for perspective and geoda.ai project names for consistency

<img width="942" height="942" alt="image" src="https://github.com/user-attachments/assets/d7645d7d-3951-4c97-bfdb-48a65ff2c2d9" />


